### PR TITLE
Removed constructor from ProductInterface

### DIFF
--- a/Model/Product/ProductInterface.php
+++ b/Model/Product/ProductInterface.php
@@ -20,8 +20,6 @@ interface ProductInterface
 {
     const RESOURCE_KEY = 'products';
 
-    public function __construct(string $id, string $code);
-
     public function getId(): string;
 
     public function getCode(): string;


### PR DESCRIPTION
With the constructor defined in the interface, PHP crashes with the following Error:
```
Fatal Compile Error: Declaration of Proxies\__CG__\Sulu\Bundle\SyliusConsumerBundle\Model\Product\Product::__construct($initializer = NULL, $cloner = NULL) must be compatible with Sulu\Bundle\SyliusConsumerBundle\Model\Product\ProductInterface::__construct(string $id, string $code) {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalErrorException(code: 0): Compile Error: Declaration of Proxies\\__CG__\\Sulu\\Bundle\\SyliusConsumerBundle\\Model\\Product\\Product::__construct($initializer = NULL, $cloner = NULL) must be compatible with Sulu\\Bundle\\SyliusConsumerBundle\\Model\\Product\\ProductInterface::__construct(string $id, string $code) at /Users/michaelscharl/Projects/steffen-shop/steffen-sulu/var/cache/website/dev/doctrine/orm/Proxies/__CG__SuluBundleSyliusConsumerBundleModelProductProduct.php:8)"} []
```

I assume this is due to some kind of doctrines lazy loading. When the Product of a ProductVariant is not loaded doctrine uses this proxy class with a custom constructor and this constructor does not conform with the Interface.

This may also happen to other Models. At the moment it only occurred on this one.