### PR TITLE
Make taxon description optional

### DIFF
--- a/Payload/TaxonTranslationPayload.php
+++ b/Payload/TaxonTranslationPayload.php
@@ -61,7 +61,10 @@ class TaxonTranslationPayload
 
     public function getDescription(): string
     {
-        return $this->payload->getStringValue('description');
+        if (!$this->payload->keyExists('description')) {
+            return '';
+        }
+        return $this->payload->getNullableStringValue('description') ?? '';
     }
 
     public function getPayload(): Payload

--- a/Payload/TaxonTranslationPayload.php
+++ b/Payload/TaxonTranslationPayload.php
@@ -64,6 +64,7 @@ class TaxonTranslationPayload
         if (!$this->payload->keyExists('description')) {
             return '';
         }
+
         return $this->payload->getNullableStringValue('description') ?? '';
     }
 


### PR DESCRIPTION
In Sylius, taxon description is an optional field. However, if you try to sync a taxon without a description to Sulu, it produces an error. This PR makes taxon description optional so it matches Sylius default settings.