### PR TITLE
Fixed an incorrect package reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Execute the following [composer](https://getcomposer.org/) commands to add the b
 project:
 
 ```bash
-composer require sulu/sylius-consumer-plugin
+composer require sulu/sylius-consumer-bundle
 ```
 
 Afterwards, visit the [bundle documentation](Resources/doc) to


### PR DESCRIPTION
The package name for this bundle is `sulu/sylius-consumer-bundle` instead of `sulu/sylius-consumer-plugin`