### PR TITLE
Fix media creation in ImageMediaAdapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ Tests/Application/var
 # npm
 Resources/js/package-lock.json
 Resources/js/node_modules
+
+# IDE
+./.idea

--- a/Adapter/ImageMediaAdapter.php
+++ b/Adapter/ImageMediaAdapter.php
@@ -18,6 +18,7 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
+use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
@@ -62,9 +63,9 @@ class ImageMediaAdapter implements ImageAdapterInterface
      * @var SyliusImageDownloaderInterface
      */
     private $syliusImageDownloader;
-    
+
     /**
-     * @var MediaRepositoryInterface
+     * @var MediaRepositoryInterface|null
      */
     private $mediaRepository;
 
@@ -75,7 +76,7 @@ class ImageMediaAdapter implements ImageAdapterInterface
         SystemCollectionManagerInterface $systemCollectionManager,
         SyliusImageDownloaderInterface $syliusImageDownloader,
         string $collectionKey,
-        MediaRepositoryInterface $mediaRepository
+        MediaRepositoryInterface $mediaRepository = null
     ) {
         $this->mediaBridgeRepository = $mediaBridgeRepository;
         $this->entityManager = $entityManager;
@@ -84,6 +85,14 @@ class ImageMediaAdapter implements ImageAdapterInterface
         $this->collectionKey = $collectionKey;
         $this->syliusImageDownloader = $syliusImageDownloader;
         $this->mediaRepository = $mediaRepository;
+
+        if (null === $mediaRepository) {
+            @trigger_deprecation(
+                'sulu/sylius-consumer-bundle',
+                '0.5',
+                'Omitting the "mediaRepository" argument is deprecated and will not longer work in SuluSyliusConsumerBundle 1.0.'
+            );
+        }
     }
 
     public function synchronize(ImagePayload $payload): void
@@ -110,7 +119,7 @@ class ImageMediaAdapter implements ImageAdapterInterface
     {
         $bridge = $this->mediaBridgeRepository->findById($payload->getId());
         if (!$bridge) {
-            $media = $this->mediaRepository->createNew();
+            $media = $this->mediaRepository ? $this->mediaRepository->createNew() : new Media();
             $bridge = $this->mediaBridgeRepository->create($payload->getId(), $media);
         }
 

--- a/Adapter/ImageMediaAdapter.php
+++ b/Adapter/ImageMediaAdapter.php
@@ -76,7 +76,7 @@ class ImageMediaAdapter implements ImageAdapterInterface
         SystemCollectionManagerInterface $systemCollectionManager,
         SyliusImageDownloaderInterface $syliusImageDownloader,
         string $collectionKey,
-        MediaRepositoryInterface $mediaRepository = null
+        ?MediaRepositoryInterface $mediaRepository = null
     ) {
         $this->mediaBridgeRepository = $mediaBridgeRepository;
         $this->entityManager = $entityManager;

--- a/Adapter/ImageMediaAdapter.php
+++ b/Adapter/ImageMediaAdapter.php
@@ -18,8 +18,8 @@ use Sulu\Bundle\MediaBundle\Entity\Collection;
 use Sulu\Bundle\MediaBundle\Entity\File;
 use Sulu\Bundle\MediaBundle\Entity\FileVersion;
 use Sulu\Bundle\MediaBundle\Entity\FileVersionMeta;
-use Sulu\Bundle\MediaBundle\Entity\Media;
 use Sulu\Bundle\MediaBundle\Entity\MediaInterface;
+use Sulu\Bundle\MediaBundle\Entity\MediaRepositoryInterface;
 use Sulu\Bundle\MediaBundle\Entity\MediaType;
 use Sulu\Bundle\MediaBundle\Media\Storage\StorageInterface;
 use Sulu\Bundle\SyliusConsumerBundle\Payload\ImagePayload;
@@ -62,6 +62,11 @@ class ImageMediaAdapter implements ImageAdapterInterface
      * @var SyliusImageDownloaderInterface
      */
     private $syliusImageDownloader;
+    
+    /**
+     * @var MediaRepositoryInterface
+     */
+    private $mediaRepository;
 
     public function __construct(
         ImageMediaBridgeRepositoryInterface $mediaBridgeRepository,
@@ -69,7 +74,8 @@ class ImageMediaAdapter implements ImageAdapterInterface
         StorageInterface $storage,
         SystemCollectionManagerInterface $systemCollectionManager,
         SyliusImageDownloaderInterface $syliusImageDownloader,
-        string $collectionKey
+        string $collectionKey,
+        MediaRepositoryInterface $mediaRepository
     ) {
         $this->mediaBridgeRepository = $mediaBridgeRepository;
         $this->entityManager = $entityManager;
@@ -77,6 +83,7 @@ class ImageMediaAdapter implements ImageAdapterInterface
         $this->systemCollectionManager = $systemCollectionManager;
         $this->collectionKey = $collectionKey;
         $this->syliusImageDownloader = $syliusImageDownloader;
+        $this->mediaRepository = $mediaRepository;
     }
 
     public function synchronize(ImagePayload $payload): void
@@ -103,7 +110,7 @@ class ImageMediaAdapter implements ImageAdapterInterface
     {
         $bridge = $this->mediaBridgeRepository->findById($payload->getId());
         if (!$bridge) {
-            $media = new Media();
+            $media = $this->mediaRepository->createNew();
             $bridge = $this->mediaBridgeRepository->create($payload->getId(), $media);
         }
 

--- a/Resources/config/image_media_adapter.xml
+++ b/Resources/config/image_media_adapter.xml
@@ -12,6 +12,7 @@
             <argument type="service" id="sulu_media.system_collections.manager"/>
             <argument type="service" id="Sulu\Bundle\SyliusConsumerBundle\Service\SyliusImageDownloaderInterface"/>
             <argument>%sulu_sylius_consumer.media_collection.key%</argument>
+            <argument type="service" id="sulu.repository.media" />
 
             <tag name="sulu_sylius_consumer.adapter.image" priority="1024"/>
         </service>


### PR DESCRIPTION
The current `ImageMediaAdapter` uses `Sulu\Bundle\MediaBundle\Entity\Media` directly which causes problems when overriding the `Media` entity. This MR fixes it by creating the entity through the repository.